### PR TITLE
Add necessary limits header

### DIFF
--- a/include/bitmask/bitmask.hpp
+++ b/include/bitmask/bitmask.hpp
@@ -29,6 +29,7 @@
 
 #include <type_traits>
 #include <functional>  // for std::hash
+#include <limits>  // for std::numeric_limits
 #include <cassert>
 
 


### PR DESCRIPTION
include/bitmask/bitmask.hpp:65:55: error: ‘numeric_limits’ is not a member of ‘std’ 
by gcc-7.3.0